### PR TITLE
Rajiv Asati's Update to plugin_impl_gobgp.go

### DIFF
--- a/bgp/gobgp/plugin_impl_gobgp.go
+++ b/bgp/gobgp/plugin_impl_gobgp.go
@@ -63,12 +63,12 @@ func (plugin *Plugin) Init() error {
 	return nil
 }
 
-// applyExternalConfig tries to find and load configuration from external filesystem and change it for injected configuration, because external configuration has higher priority.
+// applyExternalConfig tries to find and load BGP configuration from external .yaml file and change it accordingly for injected configuration, because external configuration has higher priority.
 // If external configuration is not found or can't be loaded or other problem occur, plugin.SessionConfig is not changed. This means that previous injection of plugin.SessionConfig
 // variable can be still used.
-func (plugin *Plugin) applyExternalConfig() {
-	var externalCfg *config.Bgp
-	found, err := plugin.PluginConfig.GetValue(externalCfg)	// It tries to lookup `PluginName + "-config"` in go run command flags.
+	func (plugin *Plugin) applyExternalConfig() {
+	var externalCfg config.Bgp
+	found, err := plugin.PluginConfig.GetValue(&externalCfg)	// It tries to lookup `PluginName + "-config"` in go run command flags.
 	if err != nil {
 		plugin.Log.Debug("External GoBGP plugin configuration could not load or other problem happened", err)
 		return

--- a/bgp/gobgp/plugin_impl_gobgp.go
+++ b/bgp/gobgp/plugin_impl_gobgp.go
@@ -77,7 +77,7 @@ func (plugin *Plugin) Init() error {
 		plugin.Log.Debug("External GoBGP plugin configuration was not found")
 		return
 	}
-	plugin.SessionConfig = externalCfg
+	plugin.SessionConfig = &externalCfg
 }
 
 // AfterInit starts gobgp with dedicated goroutine for watching gobgp and forwarding best path reachable ip routes to registered watchers.


### PR DESCRIPTION
This is my commit message

Signed-off-by: Rajiv Asati <rajiva@cisco.com> 

Ligato code does NOT work with external .yaml file, because of this:
```go
	func (plugin *Plugin) applyExternalConfig() {
	var externalCfg *config.Bgp
	found, err := plugin.PluginConfig.GetValue(externalCfg)
```
The above code (line 70) defined externalCfg of pointer type and passed it as-is in PluginConfig.GetValue(externalCfg) in line 71. That meant passing a different memory address from where the external file really was (remember, every time a variable is passed as parameter, a new copy of the variable is created), resulting in a garbage being passed to ParseConfigFromYamlFile function inside p.GetConfigName(), which then returned an error.

Instead, define config.Bgp variable as a pointer to the address where the external .yaml file is, and pass the same pointer in PluginConfig.GetValue(externalCfg) in line 71. 
https://gobyexample.com/pointers
http://goinbigdata.com/golang-pass-by-pointer-vs-pass-by-value/